### PR TITLE
Expose as library so others can use the defined structs and accompanying code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 
 .idea/
+.vscode/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod api;
+pub mod config;
+pub mod crypto;
+pub mod error;
+pub mod opts;
+pub mod privatebin;
+pub mod util;
+
+pub use opts::Opts;
+pub use privatebin::{DecryptedPaste, PasteFormat};
+pub use error::{PasteError, PbResult};
+pub use util::check_filesize;
+pub use api::API;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,12 @@
-mod crypto;
-mod privatebin;
-mod api;
-mod error;
-mod config;
-mod opts;
-mod util;
 
 use std::io::{Read, Write};
 use clap::{Parser};
 use data_url::{DataUrl};
-use crate::opts::Opts;
-use crate::privatebin::{DecryptedPaste, PasteFormat};
-use crate::error::{PasteError, PbResult};
-use crate::util::check_filesize;
+use pbcli::opts::Opts;
+use pbcli::privatebin::{DecryptedPaste, PasteFormat};
+use pbcli::error::{PasteError, PbResult};
+use pbcli::util::check_filesize;
+use pbcli::api::API;
 
 fn get_stdin() -> std::io::Result<String> {
     if atty::is(atty::Stream::Stdin) {
@@ -33,7 +27,7 @@ fn handle_get(opts: &Opts) -> PbResult<()> {
     let paste_id = opts.get_url().query().unwrap();
     let key = opts.get_url().fragment().ok_or(PasteError::MissingDecryptionKey)?;
 
-    let api = api::API::new(url.clone(), opts.clone());
+    let api = API::new(url.clone(), opts.clone());
     let paste = api.get_paste(paste_id)?;
 
     let content: DecryptedPaste;
@@ -79,7 +73,7 @@ fn handle_get(opts: &Opts) -> PbResult<()> {
 fn handle_post(opts: &Opts) -> PbResult<()> {
     let url = opts.get_url();
     let stdin = get_stdin()?;
-    let api = api::API::new(url.clone(), opts.clone());
+    let api = API::new(url.clone(), opts.clone());
 
     let password = match &opts.password {
         None => "",
@@ -125,7 +119,7 @@ fn handle_post(opts: &Opts) -> PbResult<()> {
 }
 
 fn main() -> PbResult<()> {
-    let args = crate::config::get_args();
+    let args = pbcli::config::get_args();
     let opts: Opts = Opts::parse_from(args);
 
     let url_has_query = opts.get_url().query().is_some();

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -70,9 +70,9 @@ pub struct Cipher {
 #[skip_serializing_none]
 #[derive(Deserialize, Debug, Serialize)]
 pub struct DecryptedPaste {
-    pub(crate) paste: String,
-    pub(crate) attachment: Option<String>,
-    pub(crate) attachment_name: Option<String>,
+    pub paste: String,
+    pub attachment: Option<String>,
+    pub attachment_name: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Serialize)]


### PR DESCRIPTION
This way, the code would be useable by other devs / applications.
 
Particularly, with [UniFFI] bindings (tbd.), this library may make it possible to create clients using Kotlin / Compose Multiplatform etc. 

[UniFFI]: https://github.com/mozilla/uniffi-rs