### PR TITLE
add useful utility functions for `PostPasteResponse`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,12 +113,9 @@ fn handle_post(opts: &Opts) -> PbResult<()> {
     let res = api.post_paste(&paste, password, opts)?;
 
     if opts.json {
-        std::io::stdout().write_all(serde_json::to_string(&res)?.as_bytes())?;
+        std::io::stdout().write_all(res.to_json().as_bytes())?;
     } else {
-        let mut url = api.base().clone();
-        url.set_query(Some(&res.id));
-        url.set_fragment(Some(&res.bs58key));
-        std::io::stdout().write_all(url.to_string().as_bytes())?;
+        std::io::stdout().write_all(res.to_url(api.base()).as_str().as_bytes())?;
         writeln!(std::io::stdout())?;
     }
 

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -83,6 +83,31 @@ pub struct PostPasteResponse {
     pub bs58key: String,
 }
 
+impl PostPasteResponse {
+    /// Return full paste url, i.e (base + ?id + #bs58key)
+    pub fn to_url(&self, base: &url::Url) -> url::Url {
+        let mut url = base.clone();
+        url.set_query(Some(&self.id));
+        url.set_fragment(Some(&self.bs58key));
+        url
+    }
+    /// Return url that can be used to delete paste
+    pub fn to_delete_url(&self, base: &url::Url) -> url::Url {
+        let mut delete_url = base.clone();
+        delete_url
+            .query_pairs_mut()
+            .append_pair("pasteid", &self.id)
+            .append_pair("deletetoken", &self.deletetoken);
+        delete_url
+    }
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+    pub fn is_success(&self) -> bool {
+        self.status == 0
+    }
+}
+
 impl Paste {
     pub fn decrypt(&self, bs58_key: &str) -> PbResult<DecryptedPaste> {
         self.decrypt_with_password(bs58_key, "")


### PR DESCRIPTION
Advantages:

-  Simplify output logic a bit
- More portable (importable by library users)
- Allows convenient `delete_url` to be displayed to user


I haven't changed the CLI output in order to keep compatibility. 

But as an idea, something like the following could be used for output when [TTY detected](https://stackoverflow.com/questions/911168/how-can-i-detect-if-my-shell-script-is-running-through-a-pipe).

```rust
        let paste_url_str = format!("Paste url: {}", res.to_url(api.base()).as_str());
        std::io::stdout().write_all(paste_url_str.as_bytes())?;
        writeln!(std::io::stdout())?;
        let delete_url_str = format!("Delete url: {}", res.to_delete_url(api.base()).as_str());
        std::io::stdout().write_all(delete_url_str.as_bytes())?;
        writeln!(std::io::stdout())?;
```

Output: 
```
Paste url: https://privatebin.net/?0a37477133f68c6c#48k1bFdRRfkMGxaKVdPEvRryABJ6cSdFk1c6RoPEbjq7
Delete url: https://privatebin.net/?pasteid=0a37477133f68c6c&deletetoken=7325797b0957881829d9f052d0c3d4281e4c6cb8bc50f1509c573669c7eff066
```