### PR TITLE
Use `PostPasteResponse` utility methods to improve json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rand_core = { version = "0.6.3", features = ["std"] }
 crypto-mac = "0.11.1"
 hmac = "0.11.0"
 sha2 = "0.9.8"
-url = "2.2.2"
+url = { version = "2.2.2", features = ["serde"] }
 atty = "0.2.14"
 rand_chacha = "0.3.1"
 dialoguer = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -40,16 +40,21 @@ precedence. To avoid specifying the host / url everytime you can
 take advantage of a config file as described [here](#Configuration-File).
 
 When posting a paste you can specify `--json` to receive post details. The output
-includes the base58 encoded key used to encrypt/decrypt the paste
-and can be used to construct the paste url.
+includes the base58 encoded key used to encrypt/decrypt the paste.
+Constructed paste url (including key) and delete url (including token) are also provided for convenience.
 
 Example output:
-```
-{"deletetoken":"ajae8c36aa945ff93a04bef4ff08fa505f96d49e1z28eb09a36l797c2eaeg952",
-"id":"e6a227cfbc0fec3e",
-"status":0,
-"url":"/?e6a227cfbc0fec3e",
-"bs58key":"31rvVHezWQH7sh7tgZGxfQJGKK4WLLCwFBL64Jr5nhLu"}
+```json
+{
+    "baseurl":"https://privatebin.net/",
+    "bs58key":"GN3qty1kAFbsGi9FbKKXigXwux1eofhiZQXNVFRMrNQd",
+    "deletetoken":"8536f6f8310ed4a9aae0e111b1763f5851cdbefe4c35e4b96bd690269635354a",
+    "deleteurl":"https://privatebin.net/?pasteid=31e2e7b19481fa7d&deletetoken=8536f6f8310ed4a9aae0e111b1763f5851cdbefe4c35e4b96bd690269635354a",
+    "id":"31e2e7b19481fa7d",
+    "pasteurl":"https://privatebin.net/?31e2e7b19481fa7d#GN3qty1kAFbsGi9FbKKXigXwux1eofhiZQXNVFRMrNQd",
+    "status":0,
+    "url":"/?31e2e7b19481fa7d"
+}
 ```
 ---
 #### Example usages to get a paste:

--- a/src/api.rs
+++ b/src/api.rs
@@ -149,6 +149,7 @@ impl API {
             .send()?;
         let mut rsv: serde_json::Value = response.json()?;
         rsv["bs58key"] = serde_json::Value::String(bs58::encode(paste_passphrase).into_string());
+        rsv["baseurl"] = serde_json::Value::String(self.base.to_string());
         let status: u32 = rsv.get("status").unwrap().as_u64().unwrap() as u32;
 
         match status {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use pbcli::error::{PasteError, PbResult};
 use pbcli::opts::Opts;
 use pbcli::privatebin::DecryptedPaste;
 use pbcli::util::check_filesize;
+use serde_json::Value;
 use std::io::{Read, Write};
 
 fn get_stdin() -> std::io::Result<String> {
@@ -113,7 +114,16 @@ fn handle_post(opts: &Opts) -> PbResult<()> {
     let res = api.post_paste(&paste, password, opts)?;
 
     if opts.json {
-        std::io::stdout().write_all(res.to_json().as_bytes())?;
+        let mut output: Value = serde_json::to_value(res.clone())?;
+        output.as_object_mut().unwrap().insert(
+            String::from("pasteurl"),
+            Value::String(res.to_url(api.base()).to_string())
+        );
+        output.as_object_mut().unwrap().insert(
+            String::from("deleteurl"),
+            Value::String(res.to_delete_url(api.base()).to_string())
+        );
+        std::io::stdout().write_all(output.to_string().as_bytes())?;
     } else {
         std::io::stdout().write_all(res.to_url(api.base()).as_str().as_bytes())?;
         writeln!(std::io::stdout())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,15 +117,15 @@ fn handle_post(opts: &Opts) -> PbResult<()> {
         let mut output: Value = serde_json::to_value(res.clone())?;
         output.as_object_mut().unwrap().insert(
             String::from("pasteurl"),
-            Value::String(res.to_url(api.base()).to_string())
+            Value::String(res.to_paste_url().to_string())
         );
         output.as_object_mut().unwrap().insert(
             String::from("deleteurl"),
-            Value::String(res.to_delete_url(api.base()).to_string())
+            Value::String(res.to_delete_url().to_string())
         );
         std::io::stdout().write_all(output.to_string().as_bytes())?;
     } else {
-        std::io::stdout().write_all(res.to_url(api.base()).as_str().as_bytes())?;
+        std::io::stdout().write_all(res.to_paste_url().as_str().as_bytes())?;
         writeln!(std::io::stdout())?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,14 +115,8 @@ fn handle_post(opts: &Opts) -> PbResult<()> {
 
     if opts.json {
         let mut output: Value = serde_json::to_value(res.clone())?;
-        output.as_object_mut().unwrap().insert(
-            String::from("pasteurl"),
-            Value::String(res.to_paste_url().to_string())
-        );
-        output.as_object_mut().unwrap().insert(
-            String::from("deleteurl"),
-            Value::String(res.to_delete_url().to_string())
-        );
+        output["pasteurl"] = Value::String(res.to_paste_url().to_string());
+        output["deleteurl"] = Value::String(res.to_delete_url().to_string());
         std::io::stdout().write_all(output.to_string().as_bytes())?;
     } else {
         std::io::stdout().write_all(res.to_paste_url().as_str().as_bytes())?;

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use serde_json::Value;
 use serde_with::skip_serializing_none;
 use std::io::ErrorKind;
+use url::Url;
 
 #[derive(Deserialize, Debug, Serialize)]
 pub enum CompressionType {
@@ -80,21 +81,21 @@ pub struct PostPasteResponse {
     pub id: String,
     pub status: u32,
     pub url: String,
-    pub baseurl: String,
+    pub baseurl: Url,
     pub bs58key: String,
 }
 
 impl PostPasteResponse {
     /// Return full paste url, i.e (base + ?id + #bs58key)
     pub fn to_paste_url(&self) -> url::Url {
-        let mut paste_url: url::Url = self.baseurl.parse().expect("Proper baseurl should be set");
+        let mut paste_url: url::Url = self.baseurl.clone();
         paste_url.set_query(Some(&self.id));
         paste_url.set_fragment(Some(&self.bs58key));
         paste_url
     }
     /// Return url that can be used to delete paste
     pub fn to_delete_url(&self) -> url::Url {
-        let mut delete_url: url::Url = self.baseurl.parse().expect("Proper baseurl should be set");
+        let mut delete_url: url::Url = self.baseurl.clone();
         delete_url
             .query_pairs_mut()
             .append_pair("pasteid", &self.id)

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -80,20 +80,21 @@ pub struct PostPasteResponse {
     pub id: String,
     pub status: u32,
     pub url: String,
+    pub baseurl: String,
     pub bs58key: String,
 }
 
 impl PostPasteResponse {
     /// Return full paste url, i.e (base + ?id + #bs58key)
-    pub fn to_url(&self, base: &url::Url) -> url::Url {
-        let mut url = base.clone();
-        url.set_query(Some(&self.id));
-        url.set_fragment(Some(&self.bs58key));
-        url
+    pub fn to_paste_url(&self) -> url::Url {
+        let mut paste_url: url::Url = self.baseurl.parse().expect("Proper baseurl should be set");
+        paste_url.set_query(Some(&self.id));
+        paste_url.set_fragment(Some(&self.bs58key));
+        paste_url
     }
     /// Return url that can be used to delete paste
-    pub fn to_delete_url(&self, base: &url::Url) -> url::Url {
-        let mut delete_url = base.clone();
+    pub fn to_delete_url(&self) -> url::Url {
+        let mut delete_url: url::Url = self.baseurl.parse().expect("Proper baseurl should be set");
         delete_url
             .query_pairs_mut()
             .append_pair("pasteid", &self.id)

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -74,7 +74,7 @@ pub struct DecryptedPaste {
     pub attachment_name: Option<String>,
 }
 
-#[derive(Deserialize, Debug, Serialize)]
+#[derive(Deserialize, Debug, Serialize, Clone)]
 pub struct PostPasteResponse {
     pub deletetoken: String,
     pub id: String,
@@ -100,7 +100,7 @@ impl PostPasteResponse {
             .append_pair("deletetoken", &self.deletetoken);
         delete_url
     }
-    pub fn to_json(&self) -> String {
+    pub fn to_json_string(&self) -> String {
         serde_json::to_string(&self).unwrap()
     }
     pub fn is_success(&self) -> bool {


### PR DESCRIPTION
Greetings, 

Like [discussed](https://github.com/Mydayyy/pbcli/pull/6#issuecomment-2034923908) previously, this commit adds _pasteurl_, and _deleteurl_ to the `--json` output.

Have added a `baseurl` field to `PostPasteResponse`. This makes it fully self-contained in regard to how we use it. 
Since `pasteurl`, and `deleteurl` can be constructed dynamically using above, I have left them out of the struct. 

Best regards.