### PR TITLE
Fix: Remove dependency on unmaintained `atty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,6 @@ name = "pbcli"
 version = "2.3.1"
 dependencies = [
  "aes-gcm",
- "atty",
  "base64",
  "bs58",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ crypto-mac = "0.11.1"
 hmac = "0.11.0"
 sha2 = "0.9.8"
 url = { version = "2.2.2", features = ["serde"] }
-atty = "0.2.14"
 rand_chacha = "0.3.1"
 dialoguer = "0.9.0"
 data-url = "0.1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,11 @@ use pbcli::opts::Opts;
 use pbcli::privatebin::DecryptedPaste;
 use pbcli::util::check_filesize;
 use serde_json::Value;
+use std::io::IsTerminal;
 use std::io::{Read, Write};
 
 fn get_stdin() -> std::io::Result<String> {
-    if atty::is(atty::Stream::Stdin) {
+    if std::io::stdin().is_terminal() {
         return Ok("".into());
     }
     let mut buffer = String::new();
@@ -43,7 +44,7 @@ fn handle_get(opts: &Opts) -> PbResult<()> {
         match paste.decrypt(key) {
             Ok(c) => content = c,
             Err(err) => {
-                if !atty::is(atty::Stream::Stdin) {
+                if !std::io::stdin().is_terminal() {
                     return Err(err);
                 }
 


### PR DESCRIPTION
atty is unmaintained for a while. And GitHub dependabot says there is a detected vulnerability in it.

So let's use new `IsTerminal` trait from stdlib instead