### PR TITLE
Do not trip on new `warn before read` feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,13 @@ fn create_dataurl(path: &std::ffi::OsStr, data: String) -> String {
 fn handle_get(opts: &Opts) -> PbResult<()> {
     let url = opts.get_url();
     let paste_id = opts.get_url().query().unwrap();
-    let key = opts
+    let fragment = opts
         .get_url()
         .fragment()
         .ok_or(PasteError::MissingDecryptionKey)?;
+    // '-' character may be found at start of fragment. This should be stripped.
+    // It is used to activate "warn before read" feature for burn on read pastes.
+    let key = fragment.strip_prefix('-').unwrap_or(fragment);
 
     let api = API::new(url.clone(), opts.clone());
     let paste = api.get_paste(paste_id)?;


### PR DESCRIPTION
Upstream privatebin introduced this new feature  https://github.com/PrivateBin/PrivateBin/pull/1237

If the fragment contains a prefix character `-` , then the ui is supposed to warn before actually getting paste, as the paste may be burn on read.

[source](https://github.com/PrivateBin/PrivateBin/pull/1237/files#diff-4c30f267da1a33c8d947890833316f48f2c58b89bc0ae567a469056ce98b96e5R80-R86)

This character can trip our reading of the bs58key. So, strip the prefix if found.