### PR TITLE
Comment post support:  api & cli

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use crate::crypto::encrypt;
+use crate::crypto::{encrypt, Decryptable};
 use crate::error::{PasteError, PbError, PbResult};
 use crate::opts::Opts;
 use crate::privatebin::{Comment, DecryptedComment, Paste, PostCommentResponse, PostPasteResponse};
@@ -120,8 +120,7 @@ impl API {
         paste.adata.burn = opts.burn as u8;
         paste.meta.expire = Some(opts.expire.clone());
 
-        let adata = &paste.adata;
-        let cipher = &adata.cipher;
+        let cipher = &paste.adata.cipher;
 
         let encrypted_content = encrypt(
             &serde_json::to_string(content)?,
@@ -130,7 +129,7 @@ impl API {
             &cipher.vec_kdf_salt()?,
             &cipher.vec_cipher_iv()?,
             cipher.kdf_iterations,
-            &serde_json::to_string(&adata)?,
+            &paste.get_adata_str(),
         )?;
 
         let b64_encrpyed_content = base64::encode(encrypted_content);
@@ -170,7 +169,6 @@ impl API {
             ..Default::default()
         };
         let cipher = &comment.adata;
-        let adata = &comment.adata;
         let paste_passphrase = bs58::decode(bs58key).into_vec()?;
 
         let encrypted_content = encrypt(
@@ -180,7 +178,7 @@ impl API {
             &cipher.vec_kdf_salt()?,
             &cipher.vec_cipher_iv()?,
             cipher.kdf_iterations,
-            &serde_json::to_string(&adata)?,
+            &comment.get_adata_str(),
         )?;
 
         let b64_encrpyed_content = base64::encode(encrypted_content);

--- a/src/api.rs
+++ b/src/api.rs
@@ -157,24 +157,25 @@ impl API {
     pub fn post_comment(
         &self,
         content: &DecryptedComment,
-        pasteid: &str,
-        parentid: &str,
+        paste_id: &str,
+        parent_id: &str,
         bs58key: &str,
         password: &str,
         opts: &Opts,
     ) -> PbResult<PostCommentResponse> {
         let mut comment = Comment {
             v: 2,
-            pasteid: pasteid.into(),
-            parentid: parentid.into(),
+            pasteid: paste_id.into(),
+            parentid: parent_id.into(),
             ..Default::default()
         };
         let cipher = &comment.adata;
         let adata = &comment.adata;
+        let paste_passphrase = bs58::decode(bs58key).into_vec()?;
 
         let encrypted_content = encrypt(
             &serde_json::to_string(content)?,
-            &base64::decode(bs58key)?,
+            &paste_passphrase,
             password,
             &base64::decode(&cipher.kdf_salt)?,
             &base64::decode(&cipher.cipher_iv)?,

--- a/src/api.rs
+++ b/src/api.rs
@@ -127,8 +127,8 @@ impl API {
             &serde_json::to_string(content)?,
             &paste_passphrase.into(),
             password,
-            &base64::decode(&cipher.kdf_salt)?,
-            &base64::decode(&cipher.cipher_iv)?,
+            &cipher.vec_kdf_salt()?,
+            &cipher.vec_cipher_iv()?,
             cipher.kdf_iterations,
             &serde_json::to_string(&adata)?,
         )?;
@@ -177,8 +177,8 @@ impl API {
             &serde_json::to_string(content)?,
             &paste_passphrase,
             password,
-            &base64::decode(&cipher.kdf_salt)?,
-            &base64::decode(&cipher.cipher_iv)?,
+            &cipher.vec_kdf_salt()?,
+            &cipher.vec_cipher_iv()?,
             cipher.kdf_iterations,
             &serde_json::to_string(&adata)?,
         )?;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -31,12 +31,24 @@ pub struct Opts {
     ))]
     pub size_limit: Option<u64>,
 
-    #[clap(long)]
+    #[clap(long, help("richer output: for delete_url, comments, etc"))]
     pub json: bool,
     #[clap(long, conflicts_with = "discussion")]
+    #[clap(help("enable burn on read for new paste"))]
     pub burn: bool,
     #[clap(long)]
+    #[clap(help("enable discussion for new paste"))]
     pub discussion: bool,
+
+    #[clap(long, requires("url"))]
+    #[clap(help("make new comment on existing paste"))]
+    pub comment: bool,
+    #[clap(long, requires("comment"), value_name = "nickname")]
+    #[clap(help("use this nick for comment"))]
+    pub comment_as: Option<String>,
+    #[clap(long, requires("comment"), value_name = "parentid")]
+    #[clap(help("reply to this parent comment"))]
+    pub comment_to: Option<String>,
 
     #[clap(long, parse(from_os_str), value_name = "FILE")]
     pub download: Option<std::path::PathBuf>,

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -32,9 +32,9 @@ pub enum PasteFormat {
 
 #[derive(Deserialize, Debug, Serialize)]
 pub struct Paste {
-    pub status: i32,
+    pub status: Option<i32>,
     pub id: String,
-    pub url: String,
+    pub url: Option<String>,
     pub v: i32,
     pub ct: String,
     pub meta: Meta,
@@ -56,11 +56,9 @@ impl Decryptable for Paste {
 
 #[derive(Deserialize, Debug, Serialize)]
 pub struct Comment {
-    pub status: Option<i32>,
     pub id: String,
     pub pasteid: String,
     pub parentid: String,
-    pub url: Option<String>,
     pub v: i32,
     pub ct: String,
     pub meta: Meta,

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -132,6 +132,17 @@ impl Default for Cipher {
     }
 }
 
+impl Cipher {
+    /// get vector of bytes representation
+    pub fn vec_cipher_iv(&self) -> PbResult<Vec<u8>> {
+        base64::decode(&self.cipher_iv).map_err(|e| e.into())
+    }
+    /// get vector of bytes representation
+    pub fn vec_kdf_salt(&self) -> PbResult<Vec<u8>> {
+        base64::decode(&self.kdf_salt).map_err(|e| e.into())
+    }
+}
+
 #[skip_serializing_none]
 #[derive(Default, Deserialize, Debug, Serialize)]
 pub struct DecryptedPaste {

--- a/src/privatebin.rs
+++ b/src/privatebin.rs
@@ -127,6 +127,13 @@ pub type DecryptedCommentsMap = HashMap<String, DecryptedComment>;
 pub type CommentsAdjacencyMap = HashMap<String, Vec<String>>;
 
 #[derive(Deserialize, Debug, Serialize, Clone)]
+pub struct PostCommentResponse {
+    pub id: String,
+    pub status: u32,
+    pub url: String,
+}
+
+#[derive(Deserialize, Debug, Serialize, Clone)]
 pub struct PostPasteResponse {
     pub deletetoken: String,
     pub id: String,


### PR DESCRIPTION
Greetings, 

This PR completes comments support by adding support for posting comments. 
In addition to the above, post paste has been updated to use defined paste type. 

The typing should help give more confidence in future updates to the code.
Also, we are able to focus sensitive/error-prone tasks like generating cipher parameters in one place. 


Best regards.
