### PR TITLE
Add --ca-cert, --insecure, and --timeout flags

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,7 @@ pub enum PasteError {
     InvalidTokenType(String),
     OidcBadRequest(serde_json::Value),
     LoggerInit(log::SetLoggerError),
+    InvalidCertificate(String),
 }
 
 impl std::error::Error for PasteError {}
@@ -76,6 +77,7 @@ impl fmt::Display for PasteError {
             PasteError::LoggerInit(err) => {
                 write!(f, "Failed to init logger: {}", err)
             }
+            PasteError::InvalidCertificate(msg) => write!(f, "{}", msg),
         }
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -108,6 +108,21 @@ pub struct Opts {
     #[clap(help("password to send to the token endpoint"))]
     pub oidc_password: Option<String>,
 
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    #[clap(long, value_name = "FILE")]
+    #[clap(help("path to a PEM CA certificate bundle for TLS verification"))]
+    pub ca_cert: Option<std::path::PathBuf>,
+
+    #[cfg_attr(feature = "uniffi", uniffi(default = false))]
+    #[clap(long)]
+    #[clap(help("accept invalid TLS certificates (insecure)"))]
+    pub insecure: bool,
+
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    #[clap(long, value_name = "SECONDS")]
+    #[clap(help("connection timeout in seconds (default: 30)"))]
+    pub timeout: Option<u64>,
+
     #[cfg_attr(feature = "uniffi", uniffi(default = false))]
     #[clap(long)]
     #[clap(help("print debug output to stderr"))]


### PR DESCRIPTION
## Summary
- Add `--ca-cert` flag to load a custom PEM CA certificate bundle for TLS verification (useful for internal/corporate CAs)
- Add `--insecure` flag to skip TLS certificate validation
- Add `--timeout` flag to configure connection timeout in seconds (default: 30)
- Centralize `reqwest::blocking::Client` construction into a single `build_client()` method

## Motivation
Corporate PrivateBin instances often use internal CAs that aren't in the default trust store. Without `--ca-cert`, connections to these instances time out silently because the TLS handshake fails.